### PR TITLE
Get rid of construct.Embedded to support python version >3.11

### DIFF
--- a/axeman/__init__.py
+++ b/axeman/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.14'
+__version__ = '1.15'
 
 if __name__ == "__main__":
     from .core import main

--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 from OpenSSL import crypto
 
-CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/log_list.json'
+CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/all_logs_list.json'
 
 CTL_INFO = "https://{}/ct/v1/get-sth"
 

--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -6,11 +6,11 @@ from collections import OrderedDict
 
 from OpenSSL import crypto
 
-CTL_LISTS = 'https://www.gstatic.com/ct/log_list/log_list.json'
+CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/log_list.json'
 
-CTL_INFO = "http://{}/ct/v1/get-sth"
+CTL_INFO = "https://{}/ct/v1/get-sth"
 
-DOWNLOAD = "http://{}/ct/v1/get-entries?start={}&end={}"
+DOWNLOAD = "https://{}/ct/v1/get-entries?start={}&end={}"
 
 from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated, Embedded
 
@@ -42,13 +42,15 @@ async def retrieve_all_ctls(session=None):
     async with session.get(CTL_LISTS) as response:
         ctl_lists = await response.json()
 
-        logs = ctl_lists['logs']
-
-        for log in logs:
-            if log['url'].endswith('/'):
-                log['url'] = log['url'][:-1]
-            owner = _get_owner(log, ctl_lists['operators'])
-            log['operated_by'] = owner
+        logs = []
+        for operator in ctl_lists['operators']:
+            owner = operator['name']
+            for log in operator['logs']:
+                log['url'] = log['url'].replace('https://','')
+                if log['url'].endswith('/'):
+                    log['url'] = log['url'][:-1]        
+                log['operated_by'] = owner
+                logs.append(log)
 
         return logs
 

--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -12,7 +12,7 @@ CTL_INFO = "https://{}/ct/v1/get-sth"
 
 DOWNLOAD = "https://{}/ct/v1/get-entries?start={}&end={}"
 
-from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated, Embedded
+from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated
 
 MerkleTreeHeader = Struct(
     "Version"         / Byte,
@@ -34,7 +34,7 @@ CertificateChain = Struct(
 
 PreCertEntry = Struct(
     "LeafCert" / Certificate,
-    Embedded(CertificateChain),
+    "CertificateChain" / CertificateChain,
     Terminated
 )
 

--- a/axeman/core.py
+++ b/axeman/core.py
@@ -190,7 +190,7 @@ def process_worker(result_info):
                 extra_data = certlib.PreCertEntry.parse(base64.b64decode(entry['extra_data']))
                 chain = [crypto.load_certificate(crypto.FILETYPE_ASN1, extra_data.LeafCert.CertData)]
 
-                for cert in extra_data.Chain:
+                for cert in extra_data.CertificateChain.Chain:
                     chain.append(
                         crypto.load_certificate(crypto.FILETYPE_ASN1, cert.CertData)
                     )
@@ -248,7 +248,7 @@ async def get_certs_and_print():
             print(log['description'])
             print("    \- URL:            {}".format(log['url']))
             print("    \- Owner:          {}".format(log_info['operated_by']))
-            print("    \- Cert Count:     {}".format(locale.format("%d", log_info['tree_size']-1, grouping=True)))
+            print("    \- Cert Count:     {}".format(locale.format_string("%d", log_info['tree_size']-1, grouping=True)))
             print("    \- Max Block Size: {}\n".format(log_info['block_size']))
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvloop
 aiohttp
 aioprocessing
 PyOpenSSL
-construct==2.9.52
+construct


### PR DESCRIPTION
Merge fix from @MohammedAdain to get rid of construct.Embedded to support python version >3.11